### PR TITLE
Update font to Mozilla Type Family (Fixes #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # HEAD
 
+-   Update font to Mozilla Type Family (#63).
 -   Update banner accept / reject HTML source order.
 
 # 1.0.0

--- a/README.md
+++ b/README.md
@@ -273,10 +273,12 @@ There's also a pre-compiled CSS file called `styles.css` in the package root whi
 ```
 
 > [!NOTE]
-> The banner CSS defines the [Inter][inter] web font as a `font-family`, falling back to `san-serif`. This package
-> does not include the Inter font directly, so the it must be loaded separately if you wish to use it.
+> The banner CSS uses the [Mozilla Type Family][mozilla-type-family] web font as a `font-family`, falling back
+> to [Inter][inter] and eventually `san-serif`. This package does not include the source fonts directly, so they
+> must be defined separetely using `@font-face` if you wish to render them.
 
 [inter]: https://rsms.me/inter/
+[mozilla-type-family]: https://github.com/mozilla/mozilla-type-family
 
 ### Browser support
 

--- a/demo/main.scss
+++ b/demo/main.scss
@@ -2,15 +2,43 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/* stylelint-disable value-keyword-case  */
+$primary-font: 'Mozilla Text', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific,
+    sans-serif;
+$secondary-font: 'Mozilla Headline', Inter, 'Helvetica Neue', Arial,
+    X-LocaleSpecific, sans-serif;
+/* stylelint-enable */
+
+// Renders locally installed Mozilla Type Family fonts.
+@font-face {
+    font-display: swap;
+    font-family: 'Mozilla Text';
+    font-style: normal;
+    font-weight: normal;
+    src: local('Mozilla Text BETA');
+}
+
+@font-face {
+    font-display: swap;
+    font-family: 'Mozilla Headline';
+    font-style: normal;
+    font-weight: normal;
+    src: local('Mozilla Headline BETA');
+}
+
 body {
     margin: 0;
 }
 
 .demo-header {
-    font-family: sans-serif;
+    font-family: $primary-font;
     margin-top: 2em;
     padding: 10px;
     text-align: center;
+}
+
+.demo-header h1 {
+    font-family: $secondary-font;
 }
 
 .demo-header p {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,6 +6,13 @@
 
 $banner-color-bg: $color-white;
 
+/* stylelint-disable value-keyword-case  */
+$primary-font: 'Mozilla Text', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific,
+    sans-serif;
+$secondary-font: 'Mozilla Headline', Inter, 'Helvetica Neue', Arial,
+    X-LocaleSpecific, sans-serif;
+/* stylelint-enable */
+
 @keyframes a-slide-up {
     0% {
         opacity: 0;
@@ -24,7 +31,7 @@ $banner-color-bg: $color-white;
     background: $banner-color-bg;
     color: $color-black;
     display: none;
-    font-family: Inter, sans-serif;
+    font-family: $primary-font;
     text-size-adjust: 100%;
 
     &.is-visible {
@@ -40,7 +47,7 @@ $banner-color-bg: $color-white;
 
     .moz-consent-banner-heading {
         color: $color-black;
-        font-family: Inter, sans-serif;
+        font-family: $secondary-font;
         font-size: 1.5rem;
         font-size: 24px;
         margin: 0 0 $spacing-md;
@@ -86,7 +93,7 @@ $banner-color-bg: $color-white;
         color: $color-white;
         cursor: pointer;
         display: inline-block;
-        font-family: Inter, sans-serif;
+        font-family: $primary-font;
         font-size: 16px;
         font-size: 1rem;
         font-weight: bold;


### PR DESCRIPTION
This PR updates the consent banner to use the same font-stack as we're using in bedrock on refresh pages.

I added some `@font-face()` rules to the demo page so that you can preview the [new font](https://github.com/mozilla/mozilla-type-family) when installed locally (I tested using the OTF format).

We'll likely need to overwrite these font styles in bedrock depending on the page (new / old), but this should be the new default going forward.